### PR TITLE
Update import paths to use GitHub repository URL

### DIFF
--- a/cmd/examples/websocket_example/main.go
+++ b/cmd/examples/websocket_example/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"deribit-api/internal/websocket"
-	"deribit-api/pkg/deribit"
-	"deribit-api/pkg/models"
+	"github.com/joaquinbejar/deribit-api/internal/websocket"
+	"github.com/joaquinbejar/deribit-api/pkg/deribit"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 	"log"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module deribit-api
+module github.com/joaquinbejar/deribit-api
 
 go 1.23.3
 

--- a/internal/rest/client.go
+++ b/internal/rest/client.go
@@ -1,12 +1,12 @@
 package rest
 
 import (
-	restmodels "deribit-api/internal/rest/models"
-	"deribit-api/pkg/deribit"
-	"deribit-api/pkg/models"
 	"encoding/json"
 	"errors"
 	"fmt"
+	restmodels "github.com/joaquinbejar/deribit-api/internal/rest/models"
+	"github.com/joaquinbejar/deribit-api/pkg/deribit"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 	"io"
 
 	"github.com/shopspring/decimal"

--- a/internal/websocket/api_account_management.go
+++ b/internal/websocket/api_account_management.go
@@ -1,7 +1,7 @@
 package websocket
 
 import (
-	"deribit-api/pkg/models"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 )
 
 func (c *Client) GetAnnouncements() (result []models.Announcement, err error) {

--- a/internal/websocket/api_authentication.go
+++ b/internal/websocket/api_authentication.go
@@ -1,7 +1,7 @@
 package websocket
 
 import (
-	"deribit-api/pkg/models"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 )
 
 func (c *Client) Auth(apiKey string, secretKey string) (err error) {

--- a/internal/websocket/api_market.go
+++ b/internal/websocket/api_market.go
@@ -1,7 +1,7 @@
 package websocket
 
 import (
-	"deribit-api/pkg/models"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 )
 
 func (c *Client) GetBookSummaryByCurrency(params *models.GetBookSummaryByCurrencyParams) (result []models.BookSummary, err error) {

--- a/internal/websocket/api_session_management.go
+++ b/internal/websocket/api_session_management.go
@@ -1,7 +1,7 @@
 package websocket
 
 import (
-	"deribit-api/pkg/models"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 )
 
 func (c *Client) SetHeartbeat(params *models.SetHeartbeatParams) (result string, err error) {

--- a/internal/websocket/api_subscription_management.go
+++ b/internal/websocket/api_subscription_management.go
@@ -1,7 +1,7 @@
 package websocket
 
 import (
-	"deribit-api/pkg/models"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 )
 
 func (c *Client) PublicSubscribe(params *models.SubscribeParams) (result models.SubscribeResponse, err error) {

--- a/internal/websocket/api_supporting.go
+++ b/internal/websocket/api_supporting.go
@@ -1,7 +1,7 @@
 package websocket
 
 import (
-	"deribit-api/pkg/models"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 )
 
 func (c *Client) GetTime() (result int64, err error) {

--- a/internal/websocket/api_trading.go
+++ b/internal/websocket/api_trading.go
@@ -1,8 +1,8 @@
 package websocket
 
 import (
-	models2 "deribit-api/internal/websocket/models"
-	"deribit-api/pkg/models"
+	models2 "github.com/joaquinbejar/deribit-api/internal/websocket/models"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 )
 
 func (c *Client) Buy(params *models.BuyParams) (result models.BuyResponse, err error) {

--- a/internal/websocket/api_wallet.go
+++ b/internal/websocket/api_wallet.go
@@ -1,7 +1,7 @@
 package websocket
 
 import (
-	"deribit-api/pkg/models"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 )
 
 func (c *Client) CancelTransferByID(params *models.CancelTransferByIDParams) (result models.Transfer, err error) {

--- a/internal/websocket/client.go
+++ b/internal/websocket/client.go
@@ -2,12 +2,12 @@ package websocket
 
 import (
 	"context"
-	websocketmodels "deribit-api/internal/websocket/models"
-	"deribit-api/pkg/deribit"
-	"deribit-api/pkg/models"
 	"encoding/json"
 	"errors"
 	"fmt"
+	websocketmodels "github.com/joaquinbejar/deribit-api/internal/websocket/models"
+	"github.com/joaquinbejar/deribit-api/pkg/deribit"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 	"log"
 	"net/http"
 	"strings"

--- a/internal/websocket/client_test.go
+++ b/internal/websocket/client_test.go
@@ -1,10 +1,10 @@
 package websocket
 
 import (
-	websocketmodels "deribit-api/internal/websocket/models"
-	"deribit-api/pkg/deribit"
-	"deribit-api/pkg/models"
 	"encoding/json"
+	websocketmodels "github.com/joaquinbejar/deribit-api/internal/websocket/models"
+	"github.com/joaquinbejar/deribit-api/pkg/deribit"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/internal/websocket/subscriptions.go
+++ b/internal/websocket/subscriptions.go
@@ -1,8 +1,8 @@
 package websocket
 
 import (
-	websockecmodels "deribit-api/internal/websocket/models"
-	"deribit-api/pkg/models"
+	websockecmodels "github.com/joaquinbejar/deribit-api/internal/websocket/models"
+	"github.com/joaquinbejar/deribit-api/pkg/models"
 	"log"
 	"strings"
 

--- a/pkg/models/buy_response.go
+++ b/pkg/models/buy_response.go
@@ -1,6 +1,6 @@
 package models
 
-import models2 "deribit-api/internal/websocket/models"
+import models2 "github.com/joaquinbejar/deribit-api/internal/websocket/models"
 
 type BuyResponse struct {
 	Trades []Trade       `json:"trades"`

--- a/pkg/models/close_position_response.go
+++ b/pkg/models/close_position_response.go
@@ -1,6 +1,6 @@
 package models
 
-import models2 "deribit-api/internal/websocket/models"
+import models2 "github.com/joaquinbejar/deribit-api/internal/websocket/models"
 
 type ClosePositionResponse struct {
 	Trades []Trade       `json:"trades"`

--- a/pkg/models/edit_response.go
+++ b/pkg/models/edit_response.go
@@ -1,6 +1,6 @@
 package models
 
-import models2 "deribit-api/internal/websocket/models"
+import models2 "github.com/joaquinbejar/deribit-api/internal/websocket/models"
 
 type EditResponse struct {
 	Trades []Trade       `json:"trades"`

--- a/pkg/models/sell_response.go
+++ b/pkg/models/sell_response.go
@@ -1,6 +1,6 @@
 package models
 
-import models2 "deribit-api/internal/websocket/models"
+import models2 "github.com/joaquinbejar/deribit-api/internal/websocket/models"
 
 type SellResponse struct {
 	Trades []Trade       `json:"trades"`

--- a/pkg/models/stop_order.go
+++ b/pkg/models/stop_order.go
@@ -1,6 +1,6 @@
 package models
 
-import models2 "deribit-api/internal/websocket/models"
+import models2 "github.com/joaquinbejar/deribit-api/internal/websocket/models"
 
 type StopOrder struct {
 	Trigger        string        `json:"trigger"`

--- a/pkg/models/subaccounts_details.go
+++ b/pkg/models/subaccounts_details.go
@@ -1,6 +1,6 @@
 package models
 
-import models2 "deribit-api/internal/websocket/models"
+import models2 "github.com/joaquinbejar/deribit-api/internal/websocket/models"
 
 type SubaccountsDetails struct {
 	OpenOrders []models2.Order `json:"open_orders"`

--- a/pkg/models/user_changes_notification.go
+++ b/pkg/models/user_changes_notification.go
@@ -1,6 +1,6 @@
 package models
 
-import models2 "deribit-api/internal/websocket/models"
+import models2 "github.com/joaquinbejar/deribit-api/internal/websocket/models"
 
 type UserChangesNotification struct {
 	Trades    []UserTrade     `json:"trades"`

--- a/pkg/models/user_order_notification.go
+++ b/pkg/models/user_order_notification.go
@@ -1,5 +1,5 @@
 package models
 
-import models2 "deribit-api/internal/websocket/models"
+import models2 "github.com/joaquinbejar/deribit-api/internal/websocket/models"
 
 type UserOrderNotification []models2.Order


### PR DESCRIPTION
Updated all import paths in the project to use the GitHub repository URL "github.com/joaquinbejar/deribit-api" instead of the previous "deribit-api". This change ensures proper package referencing and consistency across the codebase.